### PR TITLE
Add arm restraint requirement for convertibles

### DIFF
--- a/docs/2023_Tech.md
+++ b/docs/2023_Tech.md
@@ -139,6 +139,7 @@ E. Collision Protection minimum requirements
 F. Arm Restraints
 	1. Driver's window must be raised enough to keep the driver’s arms in the car or car must be equipped with a window net.
 	2. If a window net is used the window net must withstand 50-lb outward pull. Net must be releasable by driver or workers, without tools.
+	3. Arm restraints are mandatory for all occupants in convertibles, unless equipped with an OEM hardtop.
 	FF. Arm Restraints (applies to prepared cars)
 		1. Window net or arm restraints required; however, where it can be shown to the Technical Inspector that it will interfere with the safe operation of the car, this requirement can be waived.
 

--- a/docs/2023_Tech.md
+++ b/docs/2023_Tech.md
@@ -140,7 +140,7 @@ All required personal equipment must be in good condition and have proper approv
 	1. Driver's window must be raised enough to keep the driver’s arms in the car or car must be equipped with a window net.
 	2. If a window net is used the window net must withstand 50-lb outward pull. Net must be releasable by driver or workers, without tools.
 	3. Arm restraints are mandatory for all occupants in convertibles, unless equipped with an OEM hardtop.
-	3. Arm Restraints (applies to prepared cars)
+	4. Arm Restraints (applies to prepared cars)
 		1. Window net or arm restraints required; however, where it can be shown to the Technical Inspector that it will interfere with the safe operation of the car, this requirement can be waived.
 
 


### PR DESCRIPTION
Convertibles are uniquely dangerous to arms in the event of a rollover. Arm restraints should be mandatory for drivers or passengers (codrivers or fam run passengers) on those vehicles.